### PR TITLE
[fix] ToolBarの文字色を統一刷るように変更

### DIFF
--- a/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/src/main/res/layout/activity_event_detail.xml
@@ -13,6 +13,7 @@
         android:id="@+id/detail_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        style="@style/BaseToolbar"
         android:background="@color/jipriMainColor"
         android:minHeight="?attr/actionBarSize"
         android:titleTextColor="@color/white"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,8 +8,15 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
-    <style name="AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+    <style name="BaseToolbar" parent="@style/Widget.AppCompat.Toolbar">
+        <item name="android:theme">@style/ToolbarTheme</item>
+    </style>
 
+    <style name="ToolbarTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:textColorPrimary">@color/white</item>
+        <item name="android:textColorSecondary">@color/white</item>
+    </style>
+    <style name="AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
     <style name="PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
 </resources>


### PR DESCRIPTION
ToolBarの文字色がリスト画面と詳細画面で違う問題に対して、
Styleの設定を新たに追加して対応しました。