### PR TITLE
イベント作成の部署を適応

### DIFF
--- a/app/src/main/java/com/example/taross/jinkawa_android/EntryActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EntryActivity.kt
@@ -3,6 +3,7 @@ package com.example.taross.jinkawa_android
 import android.content.Intent
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
+import android.support.v7.widget.Toolbar
 import android.widget.Button
 import android.widget.EditText
 import com.example.taross.model.Event
@@ -14,6 +15,9 @@ class EntryActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_entry)
+
+        val toolbar = findViewById(R.id.toolbar_event_entry) as Toolbar
+        toolbar.title = getString(R.string.title_event_entry)
 
         var participant = Participant()
         val nameText = findViewById(R.id.text_name) as EditText

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventCreateActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventCreateActivity.kt
@@ -1,6 +1,7 @@
 package com.example.taross.jinkawa_android
 
 import android.support.v7.app.AppCompatActivity
+import android.support.v7.widget.Toolbar
 import android.os.Bundle
 import android.app.DatePickerDialog.OnDateSetListener
 import android.app.DatePickerDialog
@@ -31,12 +32,11 @@ class EventCreateActivity : AppCompatActivity(), DoneCallback {
 
         setContentView(R.layout.activity_event_create)
 
+        val toolbar = findViewById(R.id.toolbar_event_create) as Toolbar
+        toolbar.title = getString(R.string.title_event_create)
 
         val department : Spinner = findViewById(R.id.spinner_department) as Spinner
-        val personalAdapter : ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item)
-        personalAdapter.add("青年部")
-        personalAdapter.add("総務部")
-
+        val personalAdapter : ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item, resources.getStringArray(R.array.array_departments))
 
         department.adapter = personalAdapter
 

--- a/app/src/main/java/com/example/taross/jinkawa_android/NoticeCreateActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/NoticeCreateActivity.kt
@@ -2,12 +2,16 @@ package com.example.taross.jinkawa_android
 
 import android.app.Activity
 import android.os.Bundle
+import android.support.v7.widget.Toolbar
 
 class NoticeCreateActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_notice_create)
+
+        val toolbar = findViewById(R.id.toolbar_notice_create) as Toolbar
+        toolbar.title = getString(R.string.title_notice_create)
 
         val createButton = findViewById(R.id.button_notice_create)
         createButton.setOnClickListener {

--- a/app/src/main/res/layout/activity_entry.xml
+++ b/app/src/main/res/layout/activity_entry.xml
@@ -34,23 +34,20 @@
     </android.support.design.widget.AppBarLayout>
 
     <android.support.v7.widget.Toolbar
-        android:id="@+id/toolbar"
+        android:id="@+id/toolbar_event_entry"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        style="@style/BaseToolbar"
         android:background="@color/jipriMainColor"
-        app:layout_scrollFlags="scroll|enterAlways"
-        app:popupTheme="@style/PopupOverlay"
-        android:layout_alignParentTop="true"
-        android:layout_toEndOf="@+id/appbar"
-        android:layout_alignParentStart="true">
-
-    </android.support.v7.widget.Toolbar>
+        android:minHeight="?attr/actionBarSize"
+        android:titleTextColor="@color/white"
+        android:popupTheme="@android:style/Theme.Material"/>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        android:layout_below="@+id/toolbar">
+        android:layout_below="@+id/toolbar_event_entry">
 
         <android.support.design.widget.TextInputLayout
             android:id="@+id/textInput_name"
@@ -65,7 +62,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_alignParentStart="true"
-                android:layout_below="@+id/toolbar"
+                android:layout_below="@+id/toolbar_event_entry"
                 android:ems="10"
                 android:inputType="textPersonName"
                 android:hint="氏名" />

--- a/app/src/main/res/layout/activity_event_create.xml
+++ b/app/src/main/res/layout/activity_event_create.xml
@@ -7,21 +7,20 @@
     tools:context="com.example.taross.jinkawa_android.EventCreateActivity">
 
     <android.support.v7.widget.Toolbar
-        android:id="@+id/toolbar2"
+        android:id="@+id/toolbar_event_create"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         style="@style/BaseToolbar"
         android:background="@color/jipriMainColor"
         android:minHeight="?attr/actionBarSize"
         android:titleTextColor="@color/white"
-        android:title="イベント作成"
         android:popupTheme="@android:style/Theme.Material"/>
 
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_centerHorizontal="true"
-        android:layout_below="@+id/toolbar2">
+        android:layout_below="@+id/toolbar_event_create">
 
         <RelativeLayout
             android:layout_width="match_parent"
@@ -62,6 +61,7 @@
                 android:id="@+id/spinner_department"
                 android:layout_width="match_parent"
                 android:layout_height="40dp"
+                android:dropDownWidth="wrap_content"
                 android:layout_marginLeft="20dp"
                 android:layout_below="@+id/title_department" />
 

--- a/app/src/main/res/layout/activity_notice_create.xml
+++ b/app/src/main/res/layout/activity_notice_create.xml
@@ -14,7 +14,6 @@
         android:background="@color/jipriMainColor"
         android:minHeight="?attr/actionBarSize"
         android:titleTextColor="@color/white"
-        android:title="イベント作成"
         android:popupTheme="@style/PopupOverlay"/>
 
     <ScrollView

--- a/app/src/main/res/layout/spinner_item.xml
+++ b/app/src/main/res/layout/spinner_item.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@android:id/text1"
     style="?android:attr/spinnerItemStyle"
     android:singleLine="true"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:textSize="18sp"
-    android:ellipsize="marquee" />
+    android:ellipsize="marquee"
+    tools:text="青少年育成部"/>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="array_departments">
+        <item>@string/yakuin</item>
+        <item>@string/soumu</item>
+        <item>@string/seishounen</item>
+        <item>@string/josei</item>
+        <item>@string/hukushi</item>
+        <item>@string/kankyou</item>
+        <item>@string/boukabouhan</item>
+        <item>@string/koutsu</item>
+        <item>@string/jbus</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="array_departments">
-        <item>@string/yakuin</item>
         <item>@string/soumu</item>
         <item>@string/seishounen</item>
         <item>@string/josei</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,11 @@
     <string name="tab_icon_setting">オプション</string>
     <string name="title_activity_login">ログイン</string>
 
+    <!-- Strings related to page title's text -->
+    <string name="title_event_create">イベント作成</string>
+    <string name="title_notice_create">お知らせ作成</string>
+    <string name="title_event_entry">参加申し込み</string>
+
     <!-- Strings related to list's text -->
     <string name="list_text_update">最終更新日:</string>
 
@@ -42,4 +47,16 @@
     <string name="permission_rationale">"Contacts permissions are needed for providing email
         completions."
     </string>
+
+    <!-- Departments' name -->
+    <string name="yakuin">役員</string>
+    <string name="soumu">総務部</string>
+    <string name="seishounen">青少年育成部</string>
+    <string name="josei">女性部</string>
+    <string name="hukushi">福祉部</string>
+    <string name="kankyou">環境部</string>
+    <string name="boukabouhan">防火防犯部</string>
+    <string name="koutsu">交通部</string>
+    <string name="jbus">Jバス部</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,7 +49,6 @@
     </string>
 
     <!-- Departments' name -->
-    <string name="yakuin">役員</string>
     <string name="soumu">総務部</string>
     <string name="seishounen">青少年育成部</string>
     <string name="josei">女性部</string>


### PR DESCRIPTION
部署名がてきとうだったので以下に適応
役員			
総務部		
青少年育成部	
女性部		
福祉部		
環境部		
防火防犯部
交通部	
Jバス部

ついでにイベント作成・イベント参加画面のToolbarタイトルをちゃんと表示させた
