### PR TITLE
イベント編集とそのデータの更新を実装しました

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,7 @@
         <activity android:name=".ParticipantsListActivity" />
         <activity android:name=".EntryActivity" />
         <activity android:name=".EventCreateActivity" />
+        <activity android:name=".EventEditActivity" />
         <activity android:name=".NoticeCreateActivity" />
         <activity
             android:name=".LoginActivity"

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventCreateActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventCreateActivity.kt
@@ -35,13 +35,13 @@ open class EventCreateActivity : AppCompatActivity(), DoneCallback {
         val toolbar = findViewById(R.id.toolbar_event_create) as Toolbar
         toolbar.title = getString(R.string.title_event_create)
 
-        val departmentSpinner : Spinner = findViewById(R.id.spinner_department) as Spinner
-        val personalAdapter : ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item, resources.getStringArray(R.array.array_departments))
-
+        val departmentSpinner: Spinner = findViewById(R.id.spinner_department) as Spinner
+        val personalAdapter: ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item, resources.getStringArray(R.array.array_departments))
         departmentSpinner.adapter = personalAdapter
 
+        var officer = false
+
         val titleEditText = findViewById(R.id.edit_eventtitle) as EditText
-        //val departmentSpinner = findViewById(R.id.spinner_department) as Spinner
         val locationEditText = findViewById(R.id.edit_eventlocate) as EditText
         val capacityEditText = findViewById(R.id.edit_capacity) as EditText
         val officerOnlySwitch = findViewById(R.id.switch_officeronly) as Switch
@@ -49,7 +49,7 @@ open class EventCreateActivity : AppCompatActivity(), DoneCallback {
 
         val startDateTextView = findViewById(R.id.edit_eventdate_start) as TextView
         val startDateButton = findViewById(R.id.button_eventdate_start_picker) as Button
-        val startTimeTextView =findViewById(R.id.edit_eventtime_start) as TextView
+        val startTimeTextView = findViewById(R.id.edit_eventtime_start) as TextView
         val startTimeButton = findViewById(R.id.button_eventtime_start_picker) as Button
 
         val endDateTextView = findViewById(R.id.edit_eventdate_end) as TextView
@@ -74,12 +74,12 @@ open class EventCreateActivity : AppCompatActivity(), DoneCallback {
             dialog.show()
         }
 
-        startTimeButton.setOnClickListener{
+        startTimeButton.setOnClickListener {
             val calendar = Calendar.getInstance()
-            val dialog = TimePickerDialog(this, TimePickerDialog.OnTimeSetListener{view, hourOfDay, minute->
+            val dialog = TimePickerDialog(this, TimePickerDialog.OnTimeSetListener { view, hourOfDay, minute ->
 
                 startTimeTextView.text = "$hourOfDay:$minute"
-            }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE),true)
+            }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), true)
             dialog.show()
         }
 
@@ -96,12 +96,12 @@ open class EventCreateActivity : AppCompatActivity(), DoneCallback {
             dialog.show()
         }
 
-        endTimeButton.setOnClickListener{
+        endTimeButton.setOnClickListener {
             val calendar = Calendar.getInstance()
-            val dialog = TimePickerDialog(this, TimePickerDialog.OnTimeSetListener{view, hourOfDay, minute->
+            val dialog = TimePickerDialog(this, TimePickerDialog.OnTimeSetListener { view, hourOfDay, minute ->
 
                 endTimeTextView.text = "$hourOfDay:$minute"
-            }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE),true)
+            }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), true)
             dialog.show()
         }
 
@@ -118,6 +118,10 @@ open class EventCreateActivity : AppCompatActivity(), DoneCallback {
             dialog.show()
         }
 
+        officerOnlySwitch.setOnCheckedChangeListener( { buttonView, isChecked ->
+            officer = isChecked
+        })
+
         createButton.setOnClickListener{
             val title = titleEditText.text.toString()
             val department = departmentSpinner.selectedItem.toString()
@@ -129,7 +133,7 @@ open class EventCreateActivity : AppCompatActivity(), DoneCallback {
             val end_time = endTimeTextView.text.toString()
             val capacity = capacityEditText.text.toString()
             val deadline = deadlineTextView.text.toString()
-            val officer_only = officerOnlySwitch.showText
+            val officer_only = officer
 
 
             if(true){

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventCreateActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventCreateActivity.kt
@@ -19,7 +19,7 @@ import com.nifty.cloud.mb.core.NCMBException
 import org.w3c.dom.Text
 
 
-class EventCreateActivity : AppCompatActivity(), DoneCallback {
+open class EventCreateActivity : AppCompatActivity(), DoneCallback {
 
     //DoneCallBack インターフェースの実装
     override fun done(arg1: NCMBException?){
@@ -35,13 +35,13 @@ class EventCreateActivity : AppCompatActivity(), DoneCallback {
         val toolbar = findViewById(R.id.toolbar_event_create) as Toolbar
         toolbar.title = getString(R.string.title_event_create)
 
-        val department : Spinner = findViewById(R.id.spinner_department) as Spinner
+        val departmentSpinner : Spinner = findViewById(R.id.spinner_department) as Spinner
         val personalAdapter : ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item, resources.getStringArray(R.array.array_departments))
 
-        department.adapter = personalAdapter
+        departmentSpinner.adapter = personalAdapter
 
         val titleEditText = findViewById(R.id.edit_eventtitle) as EditText
-        val departmentSpinner = findViewById(R.id.spinner_department) as Spinner
+        //val departmentSpinner = findViewById(R.id.spinner_department) as Spinner
         val locationEditText = findViewById(R.id.edit_eventlocate) as EditText
         val capacityEditText = findViewById(R.id.edit_capacity) as EditText
         val officerOnlySwitch = findViewById(R.id.switch_officeronly) as Switch

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventDetailActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventDetailActivity.kt
@@ -77,6 +77,9 @@ class EventDetailActivity : AppCompatActivity() {
         if (id == R.id.action_list) {
             startActivity(Intent(applicationContext,ParticipantsListActivity::class.java).putExtra("EVENT_EXTRA", event))
             return true
+        }else if(id == R.id.action_event_edit){
+            startActivity(Intent(applicationContext,EventEditActivity::class.java).putExtra("EVENT_EXTRA", event))
+            return true
         }
 
         return super.onOptionsItemSelected(item)

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventEditActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventEditActivity.kt
@@ -88,8 +88,6 @@ class EventEditActivity: EventCreateActivity() {
 
 
             finish()
-//            val intent = Intent(applicationContext, EventDetailActivity::class.java).putExtra("EVENT_ITEM", event)
-//            startActivity(intent)
         }
     }
 

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventEditActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventEditActivity.kt
@@ -1,0 +1,147 @@
+package com.example.taross.jinkawa_android
+
+/**
+ * Created by y_snkw on 2017/11/13.
+ */
+
+import android.support.v7.app.AppCompatActivity
+import android.os.Bundle
+import android.app.DatePickerDialog.OnDateSetListener
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import android.content.Intent
+import android.text.Editable
+import android.util.Log
+import android.view.WindowManager
+import android.widget.*
+import java.util.Calendar
+import android.widget.ArrayAdapter
+import com.example.taross.model.Event
+import com.nifty.cloud.mb.core.DoneCallback
+import com.nifty.cloud.mb.core.NCMBException
+import org.w3c.dom.Text
+
+class EventEditActivity: AppCompatActivity(), DoneCallback {
+
+    //DoneCallBack インターフェースの実装
+    override fun done(arg1: NCMBException?) {
+        val intent = Intent(applicationContext, ListActivity::class.java)
+        startActivity(intent)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
+
+        setContentView(R.layout.activity_event_create)
+
+        val department: Spinner = findViewById(R.id.spinner_department) as Spinner
+        val personalAdapter: ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item)
+        personalAdapter.add("青年部")
+        personalAdapter.add("総務部")
+
+
+        department.adapter = personalAdapter
+
+        val titleEditText = findViewById(R.id.edit_eventtitle) as EditText
+        val departmentSpinner = findViewById(R.id.spinner_department) as Spinner
+        val locationEditText = findViewById(R.id.edit_eventlocate) as EditText
+        val capacityEditText = findViewById(R.id.edit_capacity) as EditText
+        val officerOnlySwitch = findViewById(R.id.switch_officeronly) as Switch
+        val descriptionEditText = findViewById(R.id.edit_description) as EditText
+
+        val startDateTextView = findViewById(R.id.edit_eventdate_start) as TextView
+        val startDateButton = findViewById(R.id.button_eventdate_start_picker) as Button
+        val startTimeTextView = findViewById(R.id.edit_eventtime_start) as TextView
+        val startTimeButton = findViewById(R.id.button_eventtime_start_picker) as Button
+
+        val endDateTextView = findViewById(R.id.edit_eventdate_end) as TextView
+        val endDateButton = findViewById(R.id.button_eventdate_end_picker) as Button
+        val endTimeTextView = findViewById(R.id.edit_eventtime_end) as TextView
+        val endTimeButton = findViewById(R.id.button_eventtime_end_picker) as Button
+
+        val deadlineTextView = findViewById(R.id.edit_deadline) as TextView
+        val deadlineButton = findViewById(R.id.button_deadline_picker) as Button
+        val createButton = findViewById(R.id.button_eventcreate) as Button
+
+        startDateButton.setOnClickListener {
+            val date = Calendar.getInstance()
+            var dialog = DatePickerDialog(this, OnDateSetListener { view, year, monthOfYear, dayOfMonth ->
+                if (!view.isShown) {
+                    return@OnDateSetListener
+                }
+                Log.d("hoge", "onDateSet")
+                val fixed_month = monthOfYear + 1
+                startDateTextView.text = "$year/$fixed_month/$dayOfMonth"
+            }, date.get(Calendar.YEAR), date.get(Calendar.MONTH), date.get(Calendar.DAY_OF_MONTH))
+            dialog.show()
+        }
+
+        startTimeButton.setOnClickListener {
+            val calendar = Calendar.getInstance()
+            val dialog = TimePickerDialog(this, TimePickerDialog.OnTimeSetListener { view, hourOfDay, minute ->
+
+                startTimeTextView.text = "$hourOfDay:$minute"
+            }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), true)
+            dialog.show()
+        }
+
+        endDateButton.setOnClickListener {
+            val date = Calendar.getInstance()
+            val dialog = DatePickerDialog(this, OnDateSetListener { view, year, monthOfYear, dayOfMonth ->
+                if (!view.isShown) {
+                    return@OnDateSetListener
+                }
+                Log.d("hoge", "onDateSet")
+                val fixed_month = monthOfYear + 1
+                endDateTextView.text = "$year/$fixed_month/$dayOfMonth"
+            }, date.get(Calendar.YEAR), date.get(Calendar.MONTH), date.get(Calendar.DAY_OF_MONTH))
+            dialog.show()
+        }
+
+        endTimeButton.setOnClickListener {
+            val calendar = Calendar.getInstance()
+            val dialog = TimePickerDialog(this, TimePickerDialog.OnTimeSetListener { view, hourOfDay, minute ->
+
+                endTimeTextView.text = "$hourOfDay:$minute"
+            }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), true)
+            dialog.show()
+        }
+
+        deadlineButton.setOnClickListener {
+            val date = Calendar.getInstance()
+            val dialog = DatePickerDialog(this, OnDateSetListener { view, year, monthOfYear, dayOfMonth ->
+                if (!view.isShown) {
+                    return@OnDateSetListener
+                }
+                Log.d("hoge", "onDateSet")
+                val fixed_month = monthOfYear + 1
+                deadlineTextView.text = "$year/$fixed_month/$dayOfMonth"
+            }, date.get(Calendar.YEAR), date.get(Calendar.MONTH), date.get(Calendar.DAY_OF_MONTH))
+            dialog.show()
+        }
+
+        createButton.setOnClickListener {
+            val title = titleEditText.text.toString()
+            val department = departmentSpinner.selectedItem.toString()
+            val description = descriptionEditText.text.toString()
+            val location = locationEditText.text.toString()
+            val start_date = startDateTextView.text.toString()
+            val start_time = startTimeTextView.text.toString()
+            val end_date = endDateTextView.text.toString()
+            val end_time = endTimeTextView.text.toString()
+            val capacity = capacityEditText.text.toString()
+            val deadline = deadlineTextView.text.toString()
+            val officer_only = officerOnlySwitch.showText
+
+
+            if (true) {
+
+            }
+
+            val event = Event(title, "", department, start_date, start_time, end_date, end_time, description, location, capacity, deadline, "", officer_only)
+            event.update(this)
+        }
+
+    }
+}

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventEditActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventEditActivity.kt
@@ -15,6 +15,8 @@ import com.nifty.cloud.mb.core.NCMBException
 
 class EventEditActivity: EventCreateActivity() {
 
+    val event :Event by lazy{intent.getParcelableExtra<Event>("EVENT_EXTRA")}
+
     //DoneCallBack インターフェースの実装
     override fun done(arg1: NCMBException?) {
         val intent = Intent(applicationContext, EventDetailActivity::class.java)
@@ -24,15 +26,14 @@ class EventEditActivity: EventCreateActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val event :Event by lazy{intent.getParcelableExtra<Event>("EVENT_EXTRA")}
-
         val toolbar = findViewById(R.id.toolbar_event_create) as Toolbar
         toolbar.title = getString(R.string.title_event_edit)
 
         val departmentSpinner : Spinner = findViewById(R.id.spinner_department) as Spinner
         val personalAdapter : ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item, resources.getStringArray(R.array.array_departments))
         departmentSpinner.adapter = personalAdapter
-        val spinnerIndex = setSpinnerSelection(personalAdapter, event.department)
+        val spinnerIndex = setSpinnerSelection(personalAdapter)
+        var officer = false
 
         val titleEditText = findViewById(R.id.edit_eventtitle) as EditText
         val locationEditText = findViewById(R.id.edit_eventlocate) as EditText
@@ -47,6 +48,7 @@ class EventEditActivity: EventCreateActivity() {
 
         val deadlineTextView = findViewById(R.id.edit_deadline) as TextView
         val editButton = findViewById(R.id.button_eventcreate) as Button
+        editButton.setText(R.string.event_edit_button_text)
 
         departmentSpinner.setSelection(spinnerIndex)
         titleEditText.setText(event.title)
@@ -60,7 +62,9 @@ class EventEditActivity: EventCreateActivity() {
         deadlineTextView.text = event.deadline
         if(event.officer_only) officerOnlySwitch.toggle()
 
-        Log.d("officer_only", officerOnlySwitch.showText.toString())
+        officerOnlySwitch.setOnCheckedChangeListener( { buttonView, isChecked ->
+            officer = isChecked
+        })
 
         editButton.setOnClickListener{
             val title = titleEditText.text.toString()
@@ -73,22 +77,26 @@ class EventEditActivity: EventCreateActivity() {
             val end_time = endTimeTextView.text.toString()
             val capacity = capacityEditText.text.toString()
             val deadline = deadlineTextView.text.toString()
-            val officer_only = officerOnlySwitch.showText
-
+            val officer_only = officer
 
             if(true){
 
             }
 
-            val event = Event(title, "" ,department, start_date, start_time, end_date, end_time, description, location, capacity, deadline, "", officer_only)
-            event.save(this)
+            val event = Event(title, event.id ,department, start_date, start_time, end_date, end_time, description, location, capacity, deadline, "", officer_only)
+            event.update(this)
+
+
+            finish()
+//            val intent = Intent(applicationContext, EventDetailActivity::class.java).putExtra("EVENT_ITEM", event)
+//            startActivity(intent)
         }
     }
 
-    fun setSpinnerSelection(spinnerAdapter: ArrayAdapter<String>, department: String): Int{
+    fun setSpinnerSelection(spinnerAdapter: ArrayAdapter<String>): Int{
         var position = 0
         for(i in 0..spinnerAdapter.count){
-            position = if(spinnerAdapter.getItem(i) == department) i else -1
+            position = if(spinnerAdapter.getItem(i) == event.department) i else -1
             if(position >= 0) break
         }
         return position

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventEditActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventEditActivity.kt
@@ -4,124 +4,65 @@ package com.example.taross.jinkawa_android
  * Created by y_snkw on 2017/11/13.
  */
 
-import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
-import android.app.DatePickerDialog.OnDateSetListener
-import android.app.DatePickerDialog
-import android.app.TimePickerDialog
 import android.content.Intent
-import android.text.Editable
+import android.support.v7.widget.Toolbar
 import android.util.Log
-import android.view.WindowManager
 import android.widget.*
-import java.util.Calendar
 import android.widget.ArrayAdapter
 import com.example.taross.model.Event
-import com.nifty.cloud.mb.core.DoneCallback
 import com.nifty.cloud.mb.core.NCMBException
-import org.w3c.dom.Text
 
-class EventEditActivity: AppCompatActivity(), DoneCallback {
+class EventEditActivity: EventCreateActivity() {
 
     //DoneCallBack インターフェースの実装
     override fun done(arg1: NCMBException?) {
-        val intent = Intent(applicationContext, ListActivity::class.java)
+        val intent = Intent(applicationContext, EventDetailActivity::class.java)
         startActivity(intent)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
 
-        setContentView(R.layout.activity_event_create)
+        val event :Event by lazy{intent.getParcelableExtra<Event>("EVENT_EXTRA")}
 
-        val department: Spinner = findViewById(R.id.spinner_department) as Spinner
-        val personalAdapter: ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item)
-        personalAdapter.add("青年部")
-        personalAdapter.add("総務部")
+        val toolbar = findViewById(R.id.toolbar_event_create) as Toolbar
+        toolbar.title = getString(R.string.title_event_edit)
 
-
-        department.adapter = personalAdapter
+        val departmentSpinner : Spinner = findViewById(R.id.spinner_department) as Spinner
+        val personalAdapter : ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item, resources.getStringArray(R.array.array_departments))
+        departmentSpinner.adapter = personalAdapter
+        val spinnerIndex = setSpinnerSelection(personalAdapter, event.department)
 
         val titleEditText = findViewById(R.id.edit_eventtitle) as EditText
-        val departmentSpinner = findViewById(R.id.spinner_department) as Spinner
         val locationEditText = findViewById(R.id.edit_eventlocate) as EditText
         val capacityEditText = findViewById(R.id.edit_capacity) as EditText
         val officerOnlySwitch = findViewById(R.id.switch_officeronly) as Switch
         val descriptionEditText = findViewById(R.id.edit_description) as EditText
 
         val startDateTextView = findViewById(R.id.edit_eventdate_start) as TextView
-        val startDateButton = findViewById(R.id.button_eventdate_start_picker) as Button
-        val startTimeTextView = findViewById(R.id.edit_eventtime_start) as TextView
-        val startTimeButton = findViewById(R.id.button_eventtime_start_picker) as Button
-
+        val startTimeTextView =findViewById(R.id.edit_eventtime_start) as TextView
         val endDateTextView = findViewById(R.id.edit_eventdate_end) as TextView
-        val endDateButton = findViewById(R.id.button_eventdate_end_picker) as Button
         val endTimeTextView = findViewById(R.id.edit_eventtime_end) as TextView
-        val endTimeButton = findViewById(R.id.button_eventtime_end_picker) as Button
 
         val deadlineTextView = findViewById(R.id.edit_deadline) as TextView
-        val deadlineButton = findViewById(R.id.button_deadline_picker) as Button
-        val createButton = findViewById(R.id.button_eventcreate) as Button
+        val editButton = findViewById(R.id.button_eventcreate) as Button
 
-        startDateButton.setOnClickListener {
-            val date = Calendar.getInstance()
-            var dialog = DatePickerDialog(this, OnDateSetListener { view, year, monthOfYear, dayOfMonth ->
-                if (!view.isShown) {
-                    return@OnDateSetListener
-                }
-                Log.d("hoge", "onDateSet")
-                val fixed_month = monthOfYear + 1
-                startDateTextView.text = "$year/$fixed_month/$dayOfMonth"
-            }, date.get(Calendar.YEAR), date.get(Calendar.MONTH), date.get(Calendar.DAY_OF_MONTH))
-            dialog.show()
-        }
+        departmentSpinner.setSelection(spinnerIndex)
+        titleEditText.setText(event.title)
+        locationEditText.setText(event.location)
+        capacityEditText.setText(event.capacity)
+        descriptionEditText.setText(event.description)
+        startDateTextView.text = event.date_start
+        startTimeTextView.text = event.time_start
+        endDateTextView.text = event.date_end
+        endTimeTextView.text = event.time_end
+        deadlineTextView.text = event.deadline
+        if(event.officer_only) officerOnlySwitch.toggle()
 
-        startTimeButton.setOnClickListener {
-            val calendar = Calendar.getInstance()
-            val dialog = TimePickerDialog(this, TimePickerDialog.OnTimeSetListener { view, hourOfDay, minute ->
+        Log.d("officer_only", officerOnlySwitch.showText.toString())
 
-                startTimeTextView.text = "$hourOfDay:$minute"
-            }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), true)
-            dialog.show()
-        }
-
-        endDateButton.setOnClickListener {
-            val date = Calendar.getInstance()
-            val dialog = DatePickerDialog(this, OnDateSetListener { view, year, monthOfYear, dayOfMonth ->
-                if (!view.isShown) {
-                    return@OnDateSetListener
-                }
-                Log.d("hoge", "onDateSet")
-                val fixed_month = monthOfYear + 1
-                endDateTextView.text = "$year/$fixed_month/$dayOfMonth"
-            }, date.get(Calendar.YEAR), date.get(Calendar.MONTH), date.get(Calendar.DAY_OF_MONTH))
-            dialog.show()
-        }
-
-        endTimeButton.setOnClickListener {
-            val calendar = Calendar.getInstance()
-            val dialog = TimePickerDialog(this, TimePickerDialog.OnTimeSetListener { view, hourOfDay, minute ->
-
-                endTimeTextView.text = "$hourOfDay:$minute"
-            }, calendar.get(Calendar.HOUR_OF_DAY), calendar.get(Calendar.MINUTE), true)
-            dialog.show()
-        }
-
-        deadlineButton.setOnClickListener {
-            val date = Calendar.getInstance()
-            val dialog = DatePickerDialog(this, OnDateSetListener { view, year, monthOfYear, dayOfMonth ->
-                if (!view.isShown) {
-                    return@OnDateSetListener
-                }
-                Log.d("hoge", "onDateSet")
-                val fixed_month = monthOfYear + 1
-                deadlineTextView.text = "$year/$fixed_month/$dayOfMonth"
-            }, date.get(Calendar.YEAR), date.get(Calendar.MONTH), date.get(Calendar.DAY_OF_MONTH))
-            dialog.show()
-        }
-
-        createButton.setOnClickListener {
+        editButton.setOnClickListener{
             val title = titleEditText.text.toString()
             val department = departmentSpinner.selectedItem.toString()
             val description = descriptionEditText.text.toString()
@@ -135,13 +76,21 @@ class EventEditActivity: AppCompatActivity(), DoneCallback {
             val officer_only = officerOnlySwitch.showText
 
 
-            if (true) {
+            if(true){
 
             }
 
-            val event = Event(title, "", department, start_date, start_time, end_date, end_time, description, location, capacity, deadline, "", officer_only)
-            event.update(this)
+            val event = Event(title, "" ,department, start_date, start_time, end_date, end_time, description, location, capacity, deadline, "", officer_only)
+            event.save(this)
         }
+    }
 
+    fun setSpinnerSelection(spinnerAdapter: ArrayAdapter<String>, department: String): Int{
+        var position = 0
+        for(i in 0..spinnerAdapter.count){
+            position = if(spinnerAdapter.getItem(i) == department) i else -1
+            if(position >= 0) break
+        }
+        return position
     }
 }

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventListAdapter.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventListAdapter.kt
@@ -49,15 +49,14 @@ class EventListAdapter(private val context: Context): BaseAdapter(){
             for(result in results){
                 val rs_updateDate = result.getString("updateDate")
                 val mrs_updateDate = rs_updateDate.substring(0, 19).replace("T", " ")
-                Log.d("updateDateValue", mrs_updateDate)
                 val event: Event = Event(
                         result.getString("name"),
                         result.getString("objectId"),
                         result.getString("department"),
                         result.getString("date_start"),
                         result.getString("start_time"),
-                        "",
-                        "",
+                        result.getString("date_end"),
+                        result.getString("end_time"),
                         result.getString("description"),
                         result.getString("location"),
                         result.getString("capacity"),
@@ -66,6 +65,7 @@ class EventListAdapter(private val context: Context): BaseAdapter(){
                         result.getBoolean("officer_only")
                 )
                 eveltList.add(event)
+                Log.d("officer", result.getBoolean("officer_only").toString())
             }
         }
         return eveltList

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventListAdapter.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventListAdapter.kt
@@ -65,7 +65,6 @@ class EventListAdapter(private val context: Context): BaseAdapter(){
                         result.getBoolean("officer_only")
                 )
                 eveltList.add(event)
-                Log.d("officer", result.getBoolean("officer_only").toString())
             }
         }
         return eveltList

--- a/app/src/main/java/com/example/taross/model/Event.kt
+++ b/app/src/main/java/com/example/taross/model/Event.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Parcel
 import android.os.Parcelable
 import android.support.v4.content.ContextCompat.startActivity
+import android.util.Log
 import com.example.taross.jinkawa_android.EventCreateActivity
 import com.example.taross.jinkawa_android.EventEditActivity
 import com.example.taross.jinkawa_android.ListActivity
@@ -71,18 +72,4 @@ data class Event(val title: String, val id:String, val department:String, val da
         data.saveInBackground(activity as DoneCallback)
     }
 
-    fun update(activity :EventEditActivity){
-        val data = NCMBObject("Event")
-        data.put("name", this.title)
-        data.put("department",this.department)
-        data.put("date_start", this.date_start)
-        data.put("start_time", this.time_start)
-        data.put("date_end", this.date_end)
-        data.put("end_time", this.time_end)
-        data.put("description", this.description)
-        data.put("location", this.location)
-        data.put("capacity", this.capacity)
-        data.put("deadline_day", this.deadline)
-        data.put("officer_only", this.officer_only)
-    }
 }

--- a/app/src/main/java/com/example/taross/model/Event.kt
+++ b/app/src/main/java/com/example/taross/model/Event.kt
@@ -98,7 +98,7 @@ data class Event(val title: String, val id:String, val department:String, val da
             try {
                 data.save()
             } catch (e: Exception) {
-                println("company data save error : " + e.cause.toString())
+                println("Event data save error : " + e.cause.toString())
             }
         }
     }

--- a/app/src/main/java/com/example/taross/model/Event.kt
+++ b/app/src/main/java/com/example/taross/model/Event.kt
@@ -12,6 +12,7 @@ import com.example.taross.jinkawa_android.ListActivity
 import com.nifty.cloud.mb.core.DoneCallback
 import com.nifty.cloud.mb.core.NCMBException
 import com.nifty.cloud.mb.core.NCMBObject
+import com.nifty.cloud.mb.core.NCMBQuery
 
 /**
  * Created by taross on 2017/08/12.
@@ -72,4 +73,33 @@ data class Event(val title: String, val id:String, val department:String, val da
         data.saveInBackground(activity as DoneCallback)
     }
 
+    fun update(activity: EventEditActivity) {
+        val query: NCMBQuery<NCMBObject> = NCMBQuery("Event")
+        query.whereEqualTo("objectId", this.id)
+        val datas: List<NCMBObject> = try {
+            query.find()
+        } catch (e: Exception) {
+            emptyList<NCMBObject>()
+        }
+        if (datas.isNotEmpty()) {
+            val data = datas[0]
+            data.put("name", this.title)
+            data.put("department", this.department)
+            data.put("date_start", this.date_start)
+            data.put("start_time", this.time_start)
+            data.put("date_end", this.date_end)
+            data.put("end_time", this.time_end)
+            data.put("description", this.description)
+            data.put("location", this.location)
+            data.put("capacity", this.capacity)
+            data.put("deadline_day", this.deadline)
+            data.put("officer_only", this.officer_only)
+
+            try {
+                data.save()
+            } catch (e: Exception) {
+                println("company data save error : " + e.cause.toString())
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/taross/model/Event.kt
+++ b/app/src/main/java/com/example/taross/model/Event.kt
@@ -6,6 +6,7 @@ import android.os.Parcel
 import android.os.Parcelable
 import android.support.v4.content.ContextCompat.startActivity
 import com.example.taross.jinkawa_android.EventCreateActivity
+import com.example.taross.jinkawa_android.EventEditActivity
 import com.example.taross.jinkawa_android.ListActivity
 import com.nifty.cloud.mb.core.DoneCallback
 import com.nifty.cloud.mb.core.NCMBException
@@ -68,5 +69,20 @@ data class Event(val title: String, val id:String, val department:String, val da
         data.put("deadline_day", this.deadline)
         data.put("officer_only", this.officer_only)
         data.saveInBackground(activity as DoneCallback)
+    }
+
+    fun update(activity :EventEditActivity){
+        val data = NCMBObject("Event")
+        data.put("name", this.title)
+        data.put("department",this.department)
+        data.put("date_start", this.date_start)
+        data.put("start_time", this.time_start)
+        data.put("date_end", this.date_end)
+        data.put("end_time", this.time_end)
+        data.put("description", this.description)
+        data.put("location", this.location)
+        data.put("capacity", this.capacity)
+        data.put("deadline_day", this.deadline)
+        data.put("officer_only", this.officer_only)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,9 @@
     <string name="title_notice_create">お知らせ作成</string>
     <string name="title_event_entry">参加申し込み</string>
 
+    <!-- Strings related to event edit's text -->
+    <string name="event_edit_button_text">イベントの編集を完了する</string>
+
     <!-- Strings related to list's text -->
     <string name="list_text_update">最終更新日:</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
 
     <!-- Strings related to page title's text -->
     <string name="title_event_create">イベント作成</string>
+    <string name="title_event_edit">イベント編集</string>
     <string name="title_notice_create">お知らせ作成</string>
     <string name="title_event_entry">参加申し込み</string>
 


### PR DESCRIPTION
イベント詳細画面からイベント編集を選択するとイベント編集画面にとびます
イベント詳細画面のイベントデータを取得して各項目につっこんでいます
officerOnlySwitchのclick時のlistenerがEventCreateActivityにも実装されていなかったのでガバガバ実装しました（いいやり方他にあるかも）
データを変更して一番下のボタンを押すことでデータを更新して一つ前のActivityであるイベント詳細画面に戻るようにしてます

(イベント編集画面でデータ更新したことをどうやってイベント詳細画面に渡すかようわからんのでおなしゃす)

↑とりあえずデータ更新を行った際の他Activityの表示データを最新のものにするのは他のissueたてたほうがいいかと