### PR TITLE
パスワード変更機能の実装しました

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,6 +76,7 @@
         <activity android:name=".NoticeCreateActivity" />
         <activity android:name=".NoticeDetailActivity" />
         <activity android:name=".NoticeEditActivity" />
+        <activity android:name=".PasswordChangeActivity" />
         <activity
             android:name=".LoginActivity"
             android:label="@string/title_activity_login"></activity>

--- a/app/src/main/java/com/example/taross/jinkawa_android/OptionFragment.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/OptionFragment.kt
@@ -1,10 +1,14 @@
 package com.example.taross.jinkawa_android
 
+import android.content.Intent
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.RelativeLayout
+import android.widget.TextView
 
 /**
  * Created by y_snkw on 2017/11/07.
@@ -12,7 +16,25 @@ import android.view.ViewGroup
 class OptionFragment: Fragment() {
     override fun onCreateView(inflater: LayoutInflater?, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
-        return inflater!!.inflate(R.layout.option_fragment, container, false)
+        val inflate = inflater!!.inflate(R.layout.option_fragment, container, false)
+
+        val accountTextView = inflate.findViewById(R.id.option_account) as TextView
+        val accountList = inflate.findViewById(R.id.option_account_list) as LinearLayout
+        val accountPassLayout = inflate.findViewById(R.id.option_account_pass) as RelativeLayout
+
+        if(LoginManager.isLogin){
+            accountTextView.setVisibility(View.VISIBLE)
+            accountList.setVisibility(View.VISIBLE)
+        }else{
+            accountTextView.setVisibility(View.GONE)
+            accountList.setVisibility(View.GONE)
+        }
+
+        accountPassLayout.setOnClickListener{
+            startActivity(Intent(activity, PasswordChangeActivity::class.java))
+        }
+
+        return inflate
     }
 
     companion object {

--- a/app/src/main/java/com/example/taross/jinkawa_android/PasswordChangeActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/PasswordChangeActivity.kt
@@ -1,0 +1,76 @@
+package com.example.taross.jinkawa_android
+
+import android.os.Bundle
+import android.support.design.widget.TextInputLayout
+import android.support.v7.app.AppCompatActivity
+import android.support.v7.widget.Toolbar
+import android.util.Log
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import com.example.taross.model.Account
+
+/**
+ * Created by y_snkw on 2017/11/19.
+ */
+class PasswordChangeActivity : AppCompatActivity() {
+
+//    //DoneCallBack インターフェースの実装
+//    override fun done(arg1: NCMBException?) {
+//        val intent = Intent(applicationContext, EventDetailActivity::class.java)
+//        startActivity(intent)
+//    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_password_change)
+
+        val toolbar = findViewById(R.id.toolbar_pass_change) as Toolbar
+        toolbar.title = getString(R.string.title_pass_change)
+
+        val idTextView = findViewById(R.id.pass_id_text) as TextView
+        idTextView.text = LoginManager.account?.userId
+
+        val oldInputLayout = findViewById(R.id.textInput_oldpass) as TextInputLayout
+        val confInputLayout = findViewById(R.id.textInput_confpass) as TextInputLayout
+        val oldPassEditView = findViewById(R.id.edit_oldpass) as EditText
+        val newPassEditView = findViewById(R.id.edit_newpass) as EditText
+        val confPassEditView = findViewById(R.id.edit_confpass) as EditText
+        val passChangeButton = findViewById(R.id.button_pass_change) as Button
+
+        passChangeButton.setOnClickListener {
+            val id = LoginManager.account?.userId
+            val nowPass = LoginManager.account?.password
+            val inOldPass = oldPassEditView.text.toString()
+            val inNewPass = newPassEditView.text.toString()
+            val inConfPass = confPassEditView.text.toString()
+
+            //エラー処理の分岐もあとで要修正
+            val success: Boolean = when{
+                nowPass != inOldPass -> {
+                    //エラー処理を追加する
+                    Log.d("Error", "not nowPass")
+                    false
+                }
+                inNewPass == "" -> {
+                    //エラー処理を追加する
+                    Log.d("Error", "newPass is Empty")
+                    false
+                }
+                inNewPass != inConfPass -> {
+                    //エラー処理を追加する
+                    Log.d("Error", "confPass is not newPass")
+                    false
+                }
+                else -> {
+                    val account = Account(id!!, inNewPass, LoginManager.account!!.role, LoginManager.account!!.auth)
+                    account.updatePass(this)
+                    true
+                }
+            }
+
+            if(success) finish()
+
+        }
+    }
+}

--- a/app/src/main/java/com/example/taross/model/Account.kt
+++ b/app/src/main/java/com/example/taross/model/Account.kt
@@ -1,8 +1,59 @@
 package com.example.taross.model
 
+import android.os.Parcel
+import android.os.Parcelable
+import com.example.taross.jinkawa_android.PasswordChangeActivity
+import com.nifty.cloud.mb.core.NCMBObject
+import com.nifty.cloud.mb.core.NCMBQuery
+
 /**
  * Created by taross on 2017/10/30.
  */
-class Account(val userId:String, val password:String, val role:String , val auth:List<String>){
-
+data class Account(val userId:String, val password:String, val role:String , val auth:List<String>) {
+//    companion object {
+//        @JvmField
+//        val CREATOR: Parcelable.Creator<Account> = object : Parcelable.Creator<Account>{
+//            override fun createFromParcel(source: Parcel): Account = source.run {
+//                Account(readString(),readString(),readString(),createStringArrayList())
+//            }
+//
+//            override fun newArray(size: Int): Array<Account?> = arrayOfNulls(size)
+//        }
+//    }
+//
+//    init {
+//
+//    }
+//
+//
+//    override fun describeContents(): Int = 0
+//
+//    override fun writeToParcel(dest: Parcel, flags: Int) {
+//
+//        dest.run {
+//            writeString(userId)
+//            writeString(password)
+//            writeString(role)
+//            writeList(auth)
+//        }
+//    }
+//
+    fun updatePass(activity: PasswordChangeActivity) {
+        val query: NCMBQuery<NCMBObject> = NCMBQuery("Accounts")
+        query.whereEqualTo("userId", this.userId)
+        val datas: List<NCMBObject> = try {
+            query.find()
+        } catch (e: Exception) {
+            emptyList<NCMBObject>()
+        }
+        if (datas.isNotEmpty()) {
+            val data = datas[0]
+            data.put("password", this.password)
+            try {
+                data.save()
+            } catch (e: Exception) {
+                println("Password save error : " + e.cause.toString())
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/taross/model/Account.kt
+++ b/app/src/main/java/com/example/taross/model/Account.kt
@@ -10,34 +10,6 @@ import com.nifty.cloud.mb.core.NCMBQuery
  * Created by taross on 2017/10/30.
  */
 data class Account(val userId:String, val password:String, val role:String , val auth:List<String>) {
-//    companion object {
-//        @JvmField
-//        val CREATOR: Parcelable.Creator<Account> = object : Parcelable.Creator<Account>{
-//            override fun createFromParcel(source: Parcel): Account = source.run {
-//                Account(readString(),readString(),readString(),createStringArrayList())
-//            }
-//
-//            override fun newArray(size: Int): Array<Account?> = arrayOfNulls(size)
-//        }
-//    }
-//
-//    init {
-//
-//    }
-//
-//
-//    override fun describeContents(): Int = 0
-//
-//    override fun writeToParcel(dest: Parcel, flags: Int) {
-//
-//        dest.run {
-//            writeString(userId)
-//            writeString(password)
-//            writeString(role)
-//            writeList(auth)
-//        }
-//    }
-//
     fun updatePass(activity: PasswordChangeActivity) {
         val query: NCMBQuery<NCMBObject> = NCMBQuery("Accounts")
         query.whereEqualTo("userId", this.userId)

--- a/app/src/main/res/layout/activity_password_change.xml
+++ b/app/src/main/res/layout/activity_password_change.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar_pass_change"
+        style="@style/BaseToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/jipriMainColor"
+        android:minHeight="?attr/actionBarSize"
+        android:popupTheme="@style/PopupOverlay" />
+
+    <RelativeLayout
+        android:id="@+id/pass_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="64dp"
+        android:layout_marginRight="64dp"
+        android:layout_marginTop="64dp"
+        android:layout_below="@+id/toolbar_pass_change">
+        <TextView
+            android:id="@+id/pass_id_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="22sp"
+            android:text="@string/password_id_title" />
+
+        <TextView
+            android:id="@+id/pass_id_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignBaseline="@id/pass_id_title"
+            android:layout_centerHorizontal="true"
+            android:textSize="22sp"
+            android:textColor="@color/black"
+            tools:text="testtestid111" />
+
+        <TextView
+        android:id="@+id/pass_oldpass_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/pass_id_title"
+        android:layout_marginTop="36dp"
+        android:textSize="16sp"
+        android:text="@string/password_old_pass_title" />
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/textInput_oldpass"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/pass_oldpass_title"
+            app:hintTextAppearance="@style/AppTheme.Design.TextAppearance.Design.Hint"
+            app:theme="@style/AppTheme.Design.TextInputLayout">
+
+            <EditText
+                android:id="@+id/edit_oldpass"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_pass_old"
+                android:inputType="textPassword"
+                tools:text="test01"/>
+        </android.support.design.widget.TextInputLayout>
+
+        <TextView
+            android:id="@+id/pass_newpass_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/textInput_oldpass"
+            android:layout_marginTop="28dp"
+            android:textSize="16sp"
+            android:text="@string/password_new_pass_title" />
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/textInput_newpass"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/pass_newpass_title"
+            app:hintTextAppearance="@style/AppTheme.Design.TextAppearance.Design.Hint"
+            app:theme="@style/AppTheme.Design.TextInputLayout">
+
+            <EditText
+                android:id="@+id/edit_newpass"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_pass_new"
+                android:inputType="textPassword" />
+        </android.support.design.widget.TextInputLayout>
+
+        <TextView
+            android:id="@+id/pass_confpass_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/textInput_newpass"
+            android:layout_marginTop="28dp"
+            android:textSize="16sp"
+            android:text="@string/password_conf_pass_title" />
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/textInput_confpass"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/pass_confpass_title"
+            app:hintTextAppearance="@style/AppTheme.Design.TextAppearance.Design.Hint"
+            app:theme="@style/AppTheme.Design.TextInputLayout">
+
+            <EditText
+                android:id="@+id/edit_confpass"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/hint_pass_conf"
+                android:inputType="textPassword" />
+
+        </android.support.design.widget.TextInputLayout>
+
+    </RelativeLayout>
+
+    <Button
+        android:id="@+id/button_pass_change"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/pass_layout"
+        android:layout_marginTop="32dp"
+        android:layout_marginLeft="48dp"
+        android:layout_marginRight="48dp"
+        android:text="@string/password_button_text"
+        android:textColor="@color/white"
+        android:textSize="18sp"
+        android:background="#616161"/>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/option_fragment.xml
+++ b/app/src/main/res/layout/option_fragment.xml
@@ -6,16 +6,16 @@
     android:layout_height="match_parent">
 
     <TextView
-        android:id="@+id/option_setting"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/lightGray"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
-        android:paddingTop="8dp"
-        android:paddingBottom="8dp"
-        android:textSize="18sp"
-        android:text="@string/option_setting_title"/>
+    android:id="@+id/option_setting"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/lightGray"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp"
+    android:textSize="18sp"
+    android:text="@string/option_setting_title"/>
 
     <LinearLayout
         android:id="@+id/option_setting_list"
@@ -84,10 +84,92 @@
     </LinearLayout>
 
     <TextView
+        android:id="@+id/option_account"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/lightGray"
+        android:layout_below="@+id/option_setting_list"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:textSize="18sp"
+        android:text="@string/option_account_title"
+        android:visibility="gone"/>
+
+    <LinearLayout
+        android:id="@+id/option_account_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/option_account"
+        android:orientation="vertical"
+        android:visibility="gone"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/option_account">
+
+        <RelativeLayout
+            android:id="@+id/option_account_pass"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clickable="true">
+
+            <TextView
+                android:id="@+id/option_account_pass_textView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingBottom="12dp"
+                android:paddingLeft="24dp"
+                android:paddingRight="24dp"
+                android:paddingTop="12dp"
+                android:text="@string/option_account_pass_text"
+                android:textSize="22sp" />
+
+            <ImageView
+                android:layout_width="36dp"
+                android:layout_height="36dp"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:layout_marginEnd="16dp"
+                android:src="@drawable/ic_chevron_right_black_24dp" />
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/option_account_logout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/option_account_logout_textView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingBottom="12dp"
+                android:paddingLeft="24dp"
+                android:paddingRight="24dp"
+                android:paddingTop="12dp"
+                android:text="@string/option_account_logout_text"
+                android:textSize="22sp" />
+
+            <ImageView
+                android:layout_width="36dp"
+                android:layout_height="36dp"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:layout_marginEnd="16dp"
+                android:src="@drawable/ic_chevron_right_black_24dp" />
+
+        </RelativeLayout>
+
+
+    </LinearLayout>
+
+    <TextView
         android:id="@+id/option_contact"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/option_setting_list"
+        android:layout_below="@+id/option_account_list"
         android:background="@color/lightGray"
         android:paddingBottom="8dp"
         android:paddingLeft="16dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="title_notice_create">お知らせ作成</string>
     <string name="title_notice_edit">お知らせ編集</string>
     <string name="title_event_entry">参加申し込み</string>
+    <string name="title_pass_change">パスワードの変更</string>
 
     <!-- Strings related to edit's text -->
     <string name="event_edit_button_text">イベントの編集を完了する</string>
@@ -46,17 +47,30 @@
     <string name="form_officer_text">役員にのみ公開する</string>
     <string name="form_event_create_text">イベントを作成する</string>
 
+    <!-- Strings related to password's text -->
+    <string name="password_id_title">ID</string>
+    <string name="password_old_pass_title">現在のパスワード</string>
+    <string name="password_new_pass_title">新しいパスワード</string>
+    <string name="password_conf_pass_title">パスワードの確認</string>
+    <string name="password_button_text">パスワードを変更する</string>
+
     <!-- Strings related to hint's text -->
     <string name="hint_event_name">10文字以内で入力してください。</string>
     <string name="hint_location">30文字以内で入力してください。</string>
     <string name="hint_capacity">5桁以内で入力してください。</string>
     <string name="hint_description">250文字以内で入力してください。</string>
+    <string name="hint_pass_old">現在のパスワードを入力</string>
+    <string name="hint_pass_new">新しいパスワードを入力</string>
+    <string name="hint_pass_conf">新しいパスワードを再入力</string>
 
 
     <!-- Strings related to option -->
     <string name="option_setting_title">設定</string>
     <string name="option_setting_form_text">フォーム履歴の確認</string>
     <string name="option_setting_notification_text">プッシュ通知の受信</string>
+    <string name="option_account_title">アカウント</string>
+    <string name="option_account_pass_text">パスワードの変更</string>
+    <string name="option_account_logout_text">ログアウト</string>
     <string name="option_setting_contact">問い合わせ</string>
     <string name="option_setting_contact_jinkawa">陣川あさひ町会</string>
 


### PR DESCRIPTION
変更後のSnackBar表示やらパスワード入力時のエラーメッセージetcをやってはいませんがとりあえずアプリ内からログイン中のアカウントのパスワードを変更できるようにしました
オプションタブのアカウント->パスワードの変更からパスワード変更画面に遷移します(クリック時のRippleとかうんぬんはやってません)
パスワード変更後アプリを再起動するまでログイン状態は続くので直後に変更前パスワードでログイン可能ですがサーバー上ではしっかりと変更を確認し、アプリ再起動後は変更前パスワードでログインできないことを確認しています(パスワード変更したら一旦強制ログアウトでも良さそう)

あ、ログインしていない状態ではオプションタブのアカウント欄は見えないようにしてます

もんごんとかはてきとーなのでゆるしておやすみ