### PR TITLE
プッシュ通知のオンオフを切り替えられるように設定変更

### DIFF
--- a/app/src/main/java/com/example/taross/jinkawa_android/Common.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/Common.kt
@@ -51,10 +51,14 @@ class NotificationHelper{
         @Throws(JSONException::class)
         fun sendPush(title:String, message:String) {
             val push = NCMBPush()
+            val query:NCMBQuery<NCMBInstallation> = NCMBQuery("Installation")
             push.action = "com.sample.pushsample.RECEIVE_PUSH"
             push.title = title
             push.message = message
             push.dialog = true
+            push.target = JSONArray("[ios, android]")
+            query.whereEqualTo("channels", "on")
+            push.setSearchCondition(query)
             push.sendInBackground { e ->
                 if (e != null) {
                     // エラー処理

--- a/app/src/main/java/com/example/taross/jinkawa_android/NoticeCreateActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/NoticeCreateActivity.kt
@@ -55,6 +55,7 @@ open class NoticeCreateActivity : AppCompatActivity(), DoneCallback {
 
             val notice = Notice(title, "", department, "20XX/YY/ZZ HH:MM", description, "", officer_only)
             notice.save(this)
+            NotificationHelper.sendPush(title, "お知らせが追加されました！")
         }
     }
 }

--- a/app/src/main/java/com/example/taross/jinkawa_android/OptionFragment.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/OptionFragment.kt
@@ -2,17 +2,30 @@ package com.example.taross.jinkawa_android
 
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Switch
 
 /**
  * Created by y_snkw on 2017/11/07.
  */
 class OptionFragment: Fragment() {
+    var pushButton: Switch? = null
+
     override fun onCreateView(inflater: LayoutInflater?, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
-        return inflater!!.inflate(R.layout.option_fragment, container, false)
+        val rootView = inflater!!.inflate(R.layout.option_fragment, container, false)
+        pushButton = rootView.findViewById(R.id.option_setting_notification_switch) as? Switch
+
+        pushButton?.setOnCheckedChangeListener { buttonView, isChecked ->
+            UserConfig.is_pushed = isChecked
+            UserConfig.sendPushConfigChange()
+            Log.d("プッシュ通知チャンネル変更", "${isChecked}に変更されました")
+        }
+
+        return rootView
     }
 
     companion object {

--- a/app/src/main/java/com/example/taross/jinkawa_android/UserConfig.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/UserConfig.kt
@@ -1,0 +1,22 @@
+package com.example.taross.jinkawa_android
+
+import com.nifty.cloud.mb.core.NCMBInstallation
+import org.json.JSONArray
+
+/**
+ * Created by taross on 2017/11/21.
+ */
+
+object UserConfig{
+    var is_pushed = true
+    val channel = arrayOf("on", "off")
+    fun sendPushConfigChange(){
+        val installation = NCMBInstallation.getCurrentInstallation()
+        installation.channels = if(is_pushed){
+            JSONArray("[on]")
+        } else{
+            JSONArray("[off]")
+        }
+        installation.saveInBackground()
+    }
+}


### PR DESCRIPTION
NCMBデータベーステーブル　```Installation```内のカラム```channels```に新しく値を加えることで対応しました。

```channels```では、アプリ内オプションタブの該当Switch（プッシュ通知切り替え？）の変更時に```on```と```off```を切り替えて登録しています。

プッシュ通知の送信処理もchannelsがonのものにだけ送信するように設定を変更してあります。
 