### PR TITLE
イベント詳細画面の画像を調節、タップで全表示にしました

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,6 +77,9 @@
         <activity android:name=".NoticeDetailActivity" />
         <activity android:name=".NoticeEditActivity" />
         <activity android:name=".PasswordChangeActivity" />
+        <activity android:name=".EventDetailTranslucentActivity"
+            android:theme="@style/Theme.TranslucentBackground">
+        </activity>
         <activity
             android:name=".LoginActivity"
             android:label="@string/title_activity_login"></activity>

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventDetailActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventDetailActivity.kt
@@ -7,10 +7,12 @@ import android.support.design.widget.FloatingActionButton
 import android.support.design.widget.Snackbar
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.Toolbar
+import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.Button
+import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
 import com.example.taross.model.Event
@@ -36,8 +38,11 @@ class EventDetailActivity : AppCompatActivity() {
         if(LoginManager.isLogin){
             setSupportActionBar(toolBar)
         }
-        val imageView = findViewById(R.id.imageView) as ImageView
-        Picasso.with(applicationContext).load("https://mb.api.cloud.nifty.com/2013-09-01/applications/zUockxBwPHqxceBH/publicFiles/${event.id}.png").into(imageView)
+        val imageButton = findViewById(R.id.imageButton_eventDetail) as ImageButton
+        Picasso.with(applicationContext).load("https://mb.api.cloud.nifty.com/2013-09-01/applications/zUockxBwPHqxceBH/publicFiles/${event.id}.png").into(imageButton)
+        imageButton.setOnClickListener({
+            Log.d("ImageClick", "ok")
+        })
 
         val departmentTextView = findViewById(R.id.detail_department_name) as TextView
         departmentTextView.text = event.department

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventDetailActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventDetailActivity.kt
@@ -41,7 +41,7 @@ class EventDetailActivity : AppCompatActivity() {
         val imageButton = findViewById(R.id.imageButton_eventDetail) as ImageButton
         Picasso.with(applicationContext).load("https://mb.api.cloud.nifty.com/2013-09-01/applications/zUockxBwPHqxceBH/publicFiles/${event.id}.png").into(imageButton)
         imageButton.setOnClickListener({
-            Log.d("ImageClick", "ok")
+            startActivity(Intent(applicationContext,EventDetailTranslucentActivity::class.java).putExtra("EVENT_EXTRA", event))
         })
 
         val departmentTextView = findViewById(R.id.detail_department_name) as TextView

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventDetailTranslucentActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventDetailTranslucentActivity.kt
@@ -1,0 +1,29 @@
+package com.example.taross.jinkawa_android
+
+import android.app.Activity
+import android.os.Bundle
+import android.widget.ImageButton
+import android.widget.ImageView
+import com.example.taross.model.Event
+import com.squareup.picasso.Picasso
+
+/**
+ * Created by y_snkw on 2017/11/24.
+ */
+class EventDetailTranslucentActivity: Activity() {
+
+    val event : Event by lazy{intent.getParcelableExtra<Event>("EVENT_EXTRA")}
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.event_detail_translucent)
+
+        val imageView = findViewById(R.id.imageView_translucent) as ImageView
+        Picasso.with(applicationContext).load("https://mb.api.cloud.nifty.com/2013-09-01/applications/zUockxBwPHqxceBH/publicFiles/${event.id}.png").into(imageView)
+
+        val closeButton = findViewById(R.id.button_translucent) as ImageButton
+        closeButton.setOnClickListener {
+            finish()
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_close_white_48dp.xml
+++ b/app/src/main/res/drawable/ic_close_white_48dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="48dp"
+        android:height="48dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"
+        android:fillColor="#FFFFFF"/>
+</vector>

--- a/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/src/main/res/layout/activity_event_detail.xml
@@ -19,13 +19,14 @@
         android:title="イベント詳細"
         android:popupTheme="@style/PopupOverlay"/>
 
-    <ImageView
-        android:id="@+id/imageView"
+    <ImageButton
+        android:id="@+id/imageButton_eventDetail"
         android:layout_width="match_parent"
         android:layout_height="200dp"
         app:srcCompat="@drawable/common_google_signin_btn_icon_dark"
         android:layout_weight="0.26"
         android:scaleType="centerCrop"
+        android:background="#888"
         android:layout_below="@+id/detail_toolbar"
         android:layout_alignParentStart="true" />
 
@@ -41,7 +42,7 @@
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@+id/imageView"
+        android:layout_below="@+id/imageButton_eventDetail"
         android:layout_alignParentStart="true"
         android:layout_above="@+id/button_entry">
 

--- a/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/src/main/res/layout/activity_event_detail.xml
@@ -25,6 +25,7 @@
         android:layout_height="200dp"
         app:srcCompat="@drawable/common_google_signin_btn_icon_dark"
         android:layout_weight="0.26"
+        android:scaleType="centerCrop"
         android:layout_below="@+id/detail_toolbar"
         android:layout_alignParentStart="true" />
 

--- a/app/src/main/res/layout/activity_event_detail.xml
+++ b/app/src/main/res/layout/activity_event_detail.xml
@@ -26,7 +26,7 @@
         app:srcCompat="@drawable/common_google_signin_btn_icon_dark"
         android:layout_weight="0.26"
         android:scaleType="centerCrop"
-        android:background="#888"
+        android:background="@null"
         android:layout_below="@+id/detail_toolbar"
         android:layout_alignParentStart="true" />
 

--- a/app/src/main/res/layout/event_detail_translucent.xml
+++ b/app/src/main/res/layout/event_detail_translucent.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageButton
+        android:id="@+id/button_translucent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginLeft="16dp"
+        android:background="@null"
+        android:src="@drawable/ic_close_white_48dp"/>
+
+    <ImageView
+        android:id="@+id/imageView_translucent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="16dp"
+        android:src="@drawable/common_google_signin_btn_icon_dark"
+        android:scaleType="fitCenter"/>
+
+</LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -26,6 +26,13 @@
         <item name="android:textColor">#aa3333</item><!--  errorの表示の色.error時の下線の色でもある -->
     </style>
 
+    <!-- 半透明背景設定 -->
+    <drawable name="transparameter">#7f000000</drawable>
+    <style name="Theme.TranslucentBackground" parent="android:style/Theme.Translucent">
+        <item name="android:windowBackground">@drawable/transparameter</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
+
     <style name="BaseToolbar" parent="@style/Widget.AppCompat.Toolbar">
         <item name="android:theme">@style/ToolbarTheme</item>
     </style>


### PR DESCRIPTION
イベント詳細画面の画像を横幅中央に合わせて表示させ、画像タップ時に背景が透過されているActivityに遷移して画像全体をみれるようにしました