### PR TITLE
権限によるイベント・お知らせ作成の制限

### DIFF
--- a/app/src/main/java/com/example/taross/jinkawa_android/EventCreateActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventCreateActivity.kt
@@ -68,7 +68,16 @@ open class EventCreateActivity : AppCompatActivity(), DoneCallback {
         toolbar.title = getString(R.string.title_event_create)
 
         val departmentSpinner: Spinner = findViewById(R.id.spinner_department) as Spinner
-        val personalAdapter: ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item, resources.getStringArray(R.array.array_departments))
+        var personalAdapter: ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item)
+
+        LoginManager.account?.let {
+            personalAdapter =
+                    if (it.auth.any{it == "all"})
+                        ArrayAdapter(applicationContext, R.layout.spinner_item, resources.getStringArray(R.array.array_departments))
+                    else
+                        ArrayAdapter(applicationContext, R.layout.spinner_item, it.auth)
+        }
+
         departmentSpinner.adapter = personalAdapter
 
         var officer = false

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventDetailActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventDetailActivity.kt
@@ -68,7 +68,11 @@ class EventDetailActivity : AppCompatActivity() {
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         // Inflate the menu; this adds items to the action bar if it is present.
-        menuInflater.inflate(R.menu.menu_event_list, menu)
+        if (LoginManager.isLogin)
+            LoginManager.account?.let {
+                if (it.auth.any{ it == "all" || it == event.department})
+                menuInflater.inflate(R.menu.menu_event_list, menu)
+            }
         return true
     }
 

--- a/app/src/main/java/com/example/taross/jinkawa_android/EventEditActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventEditActivity.kt
@@ -30,7 +30,18 @@ class EventEditActivity: EventCreateActivity() {
         toolbar.title = getString(R.string.title_event_edit)
 
         val departmentSpinner : Spinner = findViewById(R.id.spinner_department) as Spinner
-        val personalAdapter : ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item, resources.getStringArray(R.array.array_departments))
+
+        // 部署スピナーの内容追加
+        var personalAdapter: ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item)
+
+        LoginManager.account?.let {
+            personalAdapter =
+                    if (it.auth.any{it == "all"})
+                        ArrayAdapter(applicationContext, R.layout.spinner_item, resources.getStringArray(R.array.array_departments))
+                    else
+                        ArrayAdapter(applicationContext, R.layout.spinner_item, it.auth)
+        }
+
         departmentSpinner.adapter = personalAdapter
         val spinnerIndex = setSpinnerSelection(personalAdapter)
         var officer = false

--- a/app/src/main/java/com/example/taross/jinkawa_android/NoticeCreateActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/NoticeCreateActivity.kt
@@ -28,7 +28,17 @@ open class NoticeCreateActivity : AppCompatActivity(), DoneCallback {
         toolbar.title = getString(R.string.title_notice_create)
 
         val department : Spinner = findViewById(R.id.spinner_department) as Spinner
-        val personalAdapter : ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item, resources.getStringArray(R.array.array_departments))
+
+        var personalAdapter: ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item)
+
+        LoginManager.account?.let {
+            personalAdapter =
+                    if (it.auth.any{it == "all"})
+                        ArrayAdapter(applicationContext, R.layout.spinner_item, resources.getStringArray(R.array.array_departments))
+                    else
+                        ArrayAdapter(applicationContext, R.layout.spinner_item, it.auth)
+        }
+
         department.adapter = personalAdapter
         var officer = false
 

--- a/app/src/main/java/com/example/taross/jinkawa_android/NoticeDetailActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/NoticeDetailActivity.kt
@@ -51,7 +51,11 @@ class NoticeDetailActivity : AppCompatActivity() {
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         // Inflate the menu; this adds items to the action bar if it is present.
-        menuInflater.inflate(R.menu.menu_notice_list, menu)
+        if (LoginManager.isLogin)
+            LoginManager.account?.let {
+                if (it.auth.any{ it == "all" || it == notice.department})
+                    menuInflater.inflate(R.menu.menu_notice_list, menu)
+            }
         return true
     }
 

--- a/app/src/main/java/com/example/taross/jinkawa_android/NoticeEditActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/NoticeEditActivity.kt
@@ -29,7 +29,17 @@ class NoticeEditActivity: NoticeCreateActivity() {
         toolbar.title = getString(R.string.title_notice_edit)
 
         val departmentSpinner : Spinner = findViewById(R.id.spinner_department) as Spinner
-        val personalAdapter : ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item, resources.getStringArray(R.array.array_departments))
+
+        var personalAdapter: ArrayAdapter<String> = ArrayAdapter(applicationContext, R.layout.spinner_item)
+
+        LoginManager.account?.let {
+            personalAdapter =
+                    if (it.auth.any{it == "all"})
+                        ArrayAdapter(applicationContext, R.layout.spinner_item, resources.getStringArray(R.array.array_departments))
+                    else
+                        ArrayAdapter(applicationContext, R.layout.spinner_item, it.auth)
+        }
+
         departmentSpinner.adapter = personalAdapter
         val spinnerIndex = setSpinnerSelection(personalAdapter)
         var officer = false


### PR DESCRIPTION
ログインしているアカウントが持っている権限によって、
- イベントの発行元記載を制限
- イベントの編集・および参加者リストの閲覧
を制限するようにしました。