### PR TITLE
イベントリストに対してフィルタがかかっていないアダプタが渡されていた問題の解消

### DIFF
--- a/app/src/main/java/com/example/taross/jinkawa_android/EventListAdapter.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/EventListAdapter.kt
@@ -24,8 +24,8 @@ import java.io.File
  * Created by taross on 2017/08/12.
  */
 
-class EventListAdapter(private val context: Context): LoadableListAdapter(){
-    var items: MutableList<Event> = loadData()
+class EventListAdapter(private val context: Context): LoadableListAdapter<Event>(){
+    override var items: MutableList<Event> = loadData()
 
     override fun getCount(): Int = items.size
 

--- a/app/src/main/java/com/example/taross/jinkawa_android/ListActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/ListActivity.kt
@@ -1,5 +1,6 @@
 package com.example.taross.jinkawa_android
 
+import android.app.usage.UsageEvents
 import android.support.design.widget.TabLayout
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.Toolbar
@@ -25,9 +26,12 @@ import android.util.Log
 import com.example.taross.jinkawa_android.EventDetailActivity
 import android.support.v4.widget.SwipeRefreshLayout
 import android.widget.BaseAdapter
+import com.example.taross.model.Event
+import com.example.taross.model.Notice
 import com.nifty.cloud.mb.core.NCMBPush
 import org.json.JSONArray
 import org.json.JSONException
+import java.util.*
 
 
 class ListActivity : AppCompatActivity() {
@@ -161,7 +165,7 @@ class ListActivity : AppCompatActivity() {
             val listView = rootView.findViewById(R.id.listView) as ListView
 
             //エラー出るのでEventListAdapter仮置き
-            var listAdapter:LoadableListAdapter = when (page){
+            var listAdapter:LoadableListAdapter<*> = when (page){
                 1 -> EventListAdapter(context)
                 2 -> NoticeListAdapter(context)
                 else -> EventListAdapter(context)
@@ -181,10 +185,10 @@ class ListActivity : AppCompatActivity() {
             listView.adapter = listAdapter
             listView.setOnItemClickListener { parent, view, position, id ->
                 when (page) {
-                    1 -> EventDetailActivity.intent(context, EventListAdapter(context).items[position]).let {
+                    1 -> EventDetailActivity.intent(context, listAdapter.items[position] as Event).let {
                         startActivity(it)
                     }
-                    2 -> NoticeDetailActivity.intent(context, NoticeListAdapter(context).items[position]).let{
+                    2 -> NoticeDetailActivity.intent(context, listAdapter.items[position] as Notice).let{
                         startActivity(it)
                     }
                 }

--- a/app/src/main/java/com/example/taross/jinkawa_android/LoadableList.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/LoadableList.kt
@@ -4,8 +4,9 @@ package com.example.taross.jinkawa_android
  * Created by taross on 2017/11/07.
  */
 
-interface LoadableList{
+interface LoadableList<T>{
     fun loadData():MutableList<out Any>
     fun reflesh()
     fun filter()
+    var items:MutableList<T>
 }

--- a/app/src/main/java/com/example/taross/jinkawa_android/LoadableListAdapter.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/LoadableListAdapter.kt
@@ -7,6 +7,6 @@ import android.widget.BaseAdapter
  * Created by taross on 2017/11/07.
  */
 
-abstract class LoadableListAdapter : BaseAdapter(), LoadableList{
+abstract class LoadableListAdapter<T> : BaseAdapter(), LoadableList<T>{
 
 }

--- a/app/src/main/java/com/example/taross/jinkawa_android/NoticeListAdapter.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/NoticeListAdapter.kt
@@ -22,8 +22,8 @@ import com.nifty.cloud.mb.core.NCMBQuery
  * Created by taross on 2017/08/12.
  */
 
-class NoticeListAdapter(private val context: Context): LoadableListAdapter(){
-    var items: MutableList<Notice> = loadData()
+class NoticeListAdapter(private val context: Context): LoadableListAdapter<Notice>(){
+    override var items: MutableList<Notice> = loadData()
 
     override fun getCount(): Int = items.size
 


### PR DESCRIPTION
そのままではフィルタがかかった```listAdapter```を渡せない状態だったので、インターフェースを拡張して```items```も含むように変更しました。
```Event```と```Notice```も```LoadableListAdapter```インターフェースのジェネリクスに型指定を追加しています。
