### PR TITLE
オプションタブの問い合わせ・ログアウト機能を実装

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,7 +82,7 @@
         </activity>
         <activity
             android:name=".LoginActivity"
-            android:label="@string/title_activity_login"></activity>
+            android:label="@string/title_activity_login" />
 
         <receiver
             android:name="com.google.android.gms.gcm.GcmReceiver"

--- a/app/src/main/java/com/example/taross/jinkawa_android/MainActivity.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/MainActivity.kt
@@ -23,8 +23,10 @@ class MainActivity : AppCompatActivity() {
 
         val loginButton = findViewById(R.id.button2) as Button
         loginButton.setOnClickListener({
-
-            val intent = Intent(application, LoginActivity::class.java)
+            val intent = when(LoginManager.isLogin){
+                true -> Intent(application, ListActivity::class.java)
+                false -> Intent(application, LoginActivity::class.java)
+            }
             startActivity(intent)
         })
 

--- a/app/src/main/java/com/example/taross/jinkawa_android/OptionFragment.kt
+++ b/app/src/main/java/com/example/taross/jinkawa_android/OptionFragment.kt
@@ -5,6 +5,8 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import android.text.util.Linkify.PHONE_NUMBERS
+import android.text.util.Linkify.WEB_URLS
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -95,6 +97,8 @@ class OptionFragment: Fragment() {
         val accountTextView = rootView.findViewById(R.id.option_account) as TextView
         val accountList = rootView.findViewById(R.id.option_account_list) as LinearLayout
         val accountPassLayout = rootView.findViewById(R.id.option_account_pass) as RelativeLayout
+        val accountLogoutLayout = rootView.findViewById(R.id.option_account_logout) as RelativeLayout
+        val contactJinkawaLayout = rootView.findViewById(R.id.option_contact_jinkawa) as RelativeLayout
 
         if(LoginManager.isLogin){
             accountTextView.setVisibility(View.VISIBLE)
@@ -106,6 +110,33 @@ class OptionFragment: Fragment() {
 
         accountPassLayout.setOnClickListener{
             startActivity(Intent(activity, PasswordChangeActivity::class.java))
+        }
+
+        accountLogoutLayout.setOnClickListener {
+            LoginManager.logout()
+            startActivity(Intent(activity, MainActivity::class.java))
+        }
+
+        contactJinkawaLayout.setOnClickListener {
+            alert {
+                title = getString(R.string.option_setting_contact_jinkawa)
+                customView {
+                    verticalLayout {
+                        padding = dip(16)
+                        textView(getString(R.string.contact_address)) { textSize = 18f }
+                        val tell = textView(getString(R.string.contact_tell)) {
+                            textSize = 18f
+                            autoLinkMask = PHONE_NUMBERS
+                        }.lparams { topMargin = dip(16) }
+                        textView(getString(R.string.contact_facebook)) { textSize = 18f }.lparams { topMargin = dip(16) }
+                        textView(getString(R.string.contact_facebook_url)) {
+                            textSize = 15f
+                            autoLinkMask = WEB_URLS
+                        }.lparams { leftMargin = dip(8) }
+                    }
+                }
+                positiveButton(getString(R.string._return)){}
+            }.show()
         }
 
         return rootView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,6 +124,10 @@
     <string name="delete_message">本当に削除してもよろしいですか？</string>
     <string name="delete_entry_log">入力履歴を削除しました</string>
     <string name="nothing_entry_log">入力履歴がありません</string>
+    <string name="contact_address">住所：北海道函館市陣川町79-55</string>
+    <string name="contact_tell">電話番号：0138-31-8855</string>
+    <string name="contact_facebook">facebook：</string>
+    <string name="contact_facebook_url">https://ja-jp.facebook.com/jinnkawaasahi/</string>
 
     <!-- template <string name=""></string> -->
 </resources>


### PR DESCRIPTION
オプションタブの問い合わせ"陣川あさひ町会"をタップすることでダイアログが表示され、住所・電話番号・facebook情報を表示させました。電話番号とfacebookはそれぞれの値をタップすることで電話アプリに飛んだり、ブラウザに飛ぶようにしてます。

ログアウトをタップすることでLoginManager.is_loginをfalseにしてMainActivityに飛ぶようにしてます。またLoginManager.is_loginがtrueの場合MainActivityの"町会役員はコチラ"をタップするとLoginActivityではなくListActivityに遷移するようにしました。
ただし、現状のAndroid版じぷりの仕様上、ログアウトの機能の必要性があまり感じられないので削除することも検討して良いと思います。